### PR TITLE
Add component tests and testing setup

### DIFF
--- a/components/panels/HistoryIndicator.test.tsx
+++ b/components/panels/HistoryIndicator.test.tsx
@@ -1,0 +1,31 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HistoryIndicator } from './HistoryIndicator';
+import { useEditorStore } from '@/store/editorStore';
+
+const initialState = useEditorStore.getState();
+
+beforeEach(() => {
+  useEditorStore.setState(initialState, true);
+});
+
+afterEach(() => {
+  useEditorStore.setState(initialState, true);
+});
+
+describe('HistoryIndicator', () => {
+  it('displays current history position', () => {
+    useEditorStore.setState({ history: [{}, {}, {}] as any, historyIndex: 1 });
+    render(<HistoryIndicator />);
+    expect(screen.getByText('History 2 / 3')).toBeInTheDocument();
+  });
+
+  it('updates when store changes', () => {
+    useEditorStore.setState({ history: [{}, {}, {}] as any, historyIndex: 1 });
+    render(<HistoryIndicator />);
+    expect(screen.getByText('History 2 / 3')).toBeInTheDocument();
+    useEditorStore.setState({ history: [{}, {}, {}, {}] as any, historyIndex: 2 });
+    expect(screen.getByText('History 3 / 4')).toBeInTheDocument();
+  });
+});

--- a/components/panels/Topbar.test.tsx
+++ b/components/panels/Topbar.test.tsx
@@ -1,0 +1,45 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Topbar } from './Topbar';
+import { useEditorStore } from '@/store/editorStore';
+
+const originalState = useEditorStore.getState();
+
+beforeEach(() => {
+  useEditorStore.setState({
+    ...originalState,
+    loadPng: vi.fn(),
+    addText: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    resetDesign: vi.fn(),
+    canvas: null,
+  });
+});
+
+afterEach(() => {
+  useEditorStore.setState(originalState, true);
+});
+
+describe('Topbar', () => {
+  it('renders action buttons', () => {
+    render(<Topbar />);
+    expect(screen.getByRole('button', { name: /Upload PNG/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add Text/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Undo/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Redo/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Reset/i })).toBeInTheDocument();
+  });
+
+  it('calls undo and redo actions', () => {
+    const undo = vi.fn();
+    const redo = vi.fn();
+    useEditorStore.setState({ undo, redo });
+    render(<Topbar />);
+    fireEvent.click(screen.getByRole('button', { name: /Undo/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Redo/i }));
+    expect(undo).toHaveBeenCalled();
+    expect(redo).toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "postcss": "8.4.41",
     "tailwindcss": "3.4.10",
     "typescript": "5.5.4",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.1"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,20 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
   test: {
-    environment: 'node',
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
     coverage: {
       provider: 'v8',
     },
+  },
+  esbuild: {
+    jsx: 'automatic',
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- configure Vitest for React component testing with jsdom and jest-dom
- add tests for HistoryIndicator and Topbar components

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: Failed to resolve import "@testing-library/jest-dom/vitest" from "vitest.setup.ts". Does the file exist?)*

------
