### PR TITLE
Add component tests without testing-library

### DIFF
--- a/components/panels/HistoryIndicator.test.tsx
+++ b/components/panels/HistoryIndicator.test.tsx
@@ -1,0 +1,45 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { HistoryIndicator } from './HistoryIndicator';
+import { useEditorStore } from '@/store/editorStore';
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+const initialState = useEditorStore.getState();
+
+beforeEach(() => {
+  useEditorStore.setState(initialState, true);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  root.unmount();
+  document.body.removeChild(container);
+  useEditorStore.setState(initialState, true);
+});
+
+describe('HistoryIndicator', () => {
+  it('displays current history position', () => {
+    useEditorStore.setState({ history: [{}, {}, {}] as any, historyIndex: 1 });
+    act(() => {
+      root.render(<HistoryIndicator />);
+    });
+    expect(container.textContent).toContain('History 2 / 3');
+  });
+
+  it('updates when store changes', () => {
+    useEditorStore.setState({ history: [{}, {}, {}] as any, historyIndex: 1 });
+    act(() => {
+      root.render(<HistoryIndicator />);
+    });
+    expect(container.textContent).toContain('History 2 / 3');
+    act(() => {
+      useEditorStore.setState({ history: [{}, {}, {}, {}] as any, historyIndex: 2 });
+    });
+    expect(container.textContent).toContain('History 3 / 4');
+  });
+});

--- a/components/panels/Topbar.test.tsx
+++ b/components/panels/Topbar.test.tsx
@@ -1,0 +1,57 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { Topbar } from './Topbar';
+import { useEditorStore } from '@/store/editorStore';
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+const originalState = useEditorStore.getState();
+
+beforeEach(() => {
+  useEditorStore.setState(originalState, true);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  root.unmount();
+  document.body.removeChild(container);
+  useEditorStore.setState(originalState, true);
+});
+
+describe('Topbar', () => {
+  it('renders action buttons', () => {
+    act(() => {
+      root.render(<Topbar />);
+    });
+    const text = container.textContent;
+    expect(text).toContain('Upload PNG');
+    expect(text).toContain('Add Text');
+    expect(text).toContain('Undo');
+    expect(text).toContain('Redo');
+    expect(text).toContain('Reset');
+  });
+
+  it('calls undo and redo actions', () => {
+    const undo = vi.fn();
+    const redo = vi.fn();
+    useEditorStore.setState({ undo, redo });
+    act(() => {
+      root.render(<Topbar />);
+    });
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const undoBtn = buttons.find((b) => b.textContent?.includes('Undo'))!;
+    const redoBtn = buttons.find((b) => b.textContent?.includes('Redo'))!;
+    act(() => {
+      undoBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    act(() => {
+      redoBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(undo).toHaveBeenCalled();
+    expect(redo).toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,20 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
   test: {
-    environment: 'node',
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
     coverage: {
       provider: 'v8',
     },
+  },
+  esbuild: {
+    jsx: 'automatic',
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;


### PR DESCRIPTION
## Summary
- add HistoryIndicator tests verifying history display and updates
- add Topbar tests ensuring action buttons render and undo/redo callbacks fire
- drop testing-library dependencies and configure React act environment for Vitest

## Testing
- `npm test`


------
