### PR TITLE
fix: cleanup react testing environment

### DIFF
--- a/components/panels/HistoryIndicator.test.tsx
+++ b/components/panels/HistoryIndicator.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { HistoryIndicator } from './HistoryIndicator';
 import { useEditorStore } from '@/store/editorStore';
 
@@ -25,7 +25,9 @@ describe('HistoryIndicator', () => {
     useEditorStore.setState({ history: [{}, {}, {}] as any, historyIndex: 1 });
     render(<HistoryIndicator />);
     expect(screen.getByText('History 2 / 3')).toBeInTheDocument();
-    useEditorStore.setState({ history: [{}, {}, {}, {}] as any, historyIndex: 2 });
+    act(() => {
+      useEditorStore.setState({ history: [{}, {}, {}, {}] as any, historyIndex: 2 });
+    });
     expect(screen.getByText('History 3 / 4')).toBeInTheDocument();
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Ensure React components are unmounted after each test to avoid
+// cross-test pollution. Without this, renders from previous tests may
+// remain in the document and cause queries like `getByText` or
+// `getByRole` to find multiple elements, leading to false failures.
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- ensure React Testing Library cleans up after each test to prevent cross-test pollution
- wrap store updates in `act` to verify HistoryIndicator responds to changes

## Testing
- `npm install --no-progress` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: vitest: not found)*

------