### PR TITLE
fix: avoid draft type error in editor store

### DIFF
--- a/store/editorStore.ts
+++ b/store/editorStore.ts
@@ -209,9 +209,7 @@ export const useEditorStore = create<EditorState>()(
         (capture as any)._t = setTimeout(capture, 300);
       });
 
-      set((s) => {
-        s.canvas = canvas;
-      });
+      set({ canvas });
 
       // Restore (guarded)
       (async () => {


### PR DESCRIPTION
## Summary
- set fabric canvas instance directly instead of mutating draft to avoid Immer WritableDraft type issues

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
